### PR TITLE
Make the todo list into a list of tasks

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,64 +1,105 @@
-import Image from "next/image";
+"use client";
+
+import { useState } from "react";
+
+interface Task {
+  id: number;
+  text: string;
+  completed: boolean;
+}
 
 export default function Home() {
+  const [tasks, setTasks] = useState<Task[]>([
+    { id: 1, text: "Learn Next.js", completed: false },
+    { id: 2, text: "Build a project", completed: false },
+    { id: 3, text: "Deploy to Vercel", completed: false },
+  ]);
+  const [newTaskText, setNewTaskText] = useState("");
+
+  const toggleTask = (id: number) => {
+    setTasks(
+      tasks.map((task) =>
+        task.id === id ? { ...task, completed: !task.completed } : task
+      )
+    );
+  };
+
+  const addTask = () => {
+    if (newTaskText.trim() === "") return;
+    const newTask: Task = {
+      id: Date.now(),
+      text: newTaskText.trim(),
+      completed: false,
+    };
+    setTasks([...tasks, newTask]);
+    setNewTaskText("");
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      addTask();
+    }
+  };
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
+      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center py-16 px-8 bg-white dark:bg-black sm:items-start">
+        <h1 className="text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50 mb-8">
+          Task List
+        </h1>
+
+        <div className="w-full max-w-md mb-6 flex gap-2">
+          <input
+            type="text"
+            value={newTaskText}
+            onChange={(e) => setNewTaskText(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Add a new task..."
+            className="flex-1 h-12 px-4 rounded-lg border border-black/[.08] dark:border-white/[.145] bg-transparent text-black dark:text-zinc-50 placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-black/20 dark:focus:ring-white/20"
+          />
+          <button
+            onClick={addTask}
+            className="h-12 px-6 rounded-lg bg-foreground text-background font-medium transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc]"
+          >
+            Add
+          </button>
+        </div>
+
+        <ul className="w-full max-w-md space-y-3">
+          {tasks.map((task) => (
+            <li
+              key={task.id}
+              className="flex items-center gap-3 p-4 rounded-lg border border-black/[.08] dark:border-white/[.145] transition-colors hover:bg-black/[.02] dark:hover:bg-white/[.02]"
             >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
+              <input
+                type="checkbox"
+                checked={task.completed}
+                onChange={() => toggleTask(task.id)}
+                className="w-5 h-5 rounded border-2 border-black/20 dark:border-white/20 cursor-pointer accent-black dark:accent-white"
+              />
+              <span
+                className={`flex-1 text-lg ${
+                  task.completed
+                    ? "line-through text-zinc-400 dark:text-zinc-600"
+                    : "text-black dark:text-zinc-50"
+                }`}
+              >
+                {task.text}
+              </span>
+            </li>
+          ))}
+        </ul>
+
+        {tasks.length === 0 && (
+          <p className="text-zinc-400 dark:text-zinc-600 text-center w-full max-w-md mt-4">
+            No tasks yet. Add one above!
           </p>
-        </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
+        )}
+
+        <p className="mt-8 text-sm text-zinc-400 dark:text-zinc-600">
+          {tasks.filter((t) => t.completed).length} of {tasks.length} tasks
+          completed
+        </p>
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
This PR converts the default Next.js landing page into a task list with checkable items, as requested in the issue.

## Changes
- **Task List UI**: Replaced the default landing page with a clean task list interface
- **Checkable Tasks**: Each task has a checkbox that can be toggled to mark it complete/incomplete
- **Add New Tasks**: Users can add new tasks via an input field (supports Enter key)
- **Visual Feedback**: Completed tasks display with strikethrough text styling
- **Progress Tracking**: Shows completion progress (e.g., "2 of 5 tasks completed")

## Features
- Pre-populated with 3 sample tasks
- Responsive design with dark mode support
- Follows existing Tailwind CSS styling conventions

_This PR was generated with [Warp](https://www.warp.dev/)._
